### PR TITLE
[Feat] TransactionRecord 영속성 객체 구현 및 필드 상수화

### DIFF
--- a/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/domain/entity/TransactionRecord.java
+++ b/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/domain/entity/TransactionRecord.java
@@ -1,0 +1,93 @@
+package com.wanderpass.transaction_service.domain.transaction_record.domain.entity;
+
+import com.wanderpass.transaction_service.domain.transaction_record.domain.type.Currency;
+import com.wanderpass.transaction_service.domain.transaction_record.domain.type.TransactionStatus;
+import com.wanderpass.transaction_service.domain.transaction_record.domain.type.TransactionType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "transaction_record")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(access = AccessLevel.PRIVATE)
+public class TransactionRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "card_id", nullable = false)
+    private Long cardId;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TransactionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TransactionStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "original_currency", nullable = false)
+    private Currency originalCurrency;
+
+    @Column(name = "original_amount", nullable = false)
+    private BigDecimal originalAmount;
+
+    @Column(nullable = false, length = 255)
+    private String description;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 충전 행위를 담은 레코드를 생성하기 위한 정적 메서드
+    public static TransactionRecord createCharge(Long cardId, BigDecimal amount, String description) {
+        return TransactionRecord.builder()
+                .cardId(cardId)
+                .amount(amount)
+                .type(TransactionType.CHARGE)
+                .status(TransactionStatus.COMPLETE)
+                .originalCurrency(Currency.KRW)
+                .originalAmount(amount)
+                .description(description)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    // 결제 행위를 담은 레코드를 생성하기 위한 정적 메서드
+    public static TransactionRecord createSpend(Long cardId, BigDecimal convertedAmount, Currency originalCurrency, BigDecimal originalAmount, String description) {
+        return TransactionRecord.builder()
+                .cardId(cardId)
+                .amount(convertedAmount)
+                .type(TransactionType.SPEND)
+                .status(TransactionStatus.PENDING)
+                .originalCurrency(originalCurrency)
+                .originalAmount(originalAmount)
+                .description(description)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private void markComplete() {
+        this.status = TransactionStatus.COMPLETE;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    private void markFailed() {
+        this.status = TransactionStatus.FAILED;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/domain/type/Currency.java
+++ b/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/domain/type/Currency.java
@@ -1,0 +1,5 @@
+package com.wanderpass.transaction_service.domain.transaction_record.domain.type;
+
+public enum Currency {
+    KRW, JPY, USD
+}

--- a/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/domain/type/TransactionStatus.java
+++ b/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/domain/type/TransactionStatus.java
@@ -1,0 +1,5 @@
+package com.wanderpass.transaction_service.domain.transaction_record.domain.type;
+
+public enum TransactionStatus {
+    PENDING, COMPLETE, FAILED
+}

--- a/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/domain/type/TransactionType.java
+++ b/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/domain/type/TransactionType.java
@@ -1,0 +1,5 @@
+package com.wanderpass.transaction_service.domain.transaction_record.domain.type;
+
+public enum TransactionType {
+    CHARGE, SPEND
+}

--- a/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/infrastructure/persistence/TransactionsRecordRepository.java
+++ b/src/main/java/com/wanderpass/transaction_service/domain/transaction_record/infrastructure/persistence/TransactionsRecordRepository.java
@@ -1,0 +1,8 @@
+package com.wanderpass.transaction_service.domain.transaction_record.infrastructure.persistence;
+
+import com.wanderpass.transaction_service.domain.transaction_record.domain.entity.TransactionRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionsRecordRepository extends JpaRepository<TransactionRecord, Long> {
+
+}


### PR DESCRIPTION
## 작업 설명
- #13 [feat] Transaction 영속성 객체 생성 및 저장 로직 구현

## 작업 목적
- TransactionRecorder 영속성 객체를 구현해서 결제나 충전에 대한 거래 내역을 저장합니다.

## 상세 작업 내용
- [x] TransactionRecord 영속성 객체 구현
- [x] TransactionRecord 영속성 객체에 필요한 컬럼

## 관련 리소스
